### PR TITLE
Fix empty side margins in starfield on wide viewports

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: https://linkedin.com/in/shortericmann
+Contact: https://linkedin.com/in/ericallenmann
 Preferred-Languages: en
 Canonical: https://eamann.com/.well-known/security.txt
 Expires: 2027-12-31T23:59:59.000Z

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: https://linkedin.com/in/shortericmann
+Preferred-Languages: en
+Canonical: https://eamann.com/.well-known/security.txt
+Expires: 2027-12-31T23:59:59.000Z

--- a/build.js
+++ b/build.js
@@ -26,7 +26,9 @@ const passthrough = [
 ];
 
 const passthroughFiles = [
-  { src: 'CNAME',       out: path.join(DIST, 'CNAME') },
+  { src: 'CNAME',      out: path.join(DIST, 'CNAME') },
+  { src: 'humans.txt', out: path.join(DIST, 'humans.txt') },
+  { src: 'robots.txt', out: path.join(DIST, 'robots.txt') },
 ];
 
 function copyDir(src, dest) {

--- a/humans.txt
+++ b/humans.txt
@@ -1,8 +1,9 @@
 /* HUMAN */
-Name:     Eric A Mann
-Location: Tualatin, Oregon
-Contact:  https://linkedin.com/in/shortericmann
-Twitter:  @shortericmann
+Name:       Eric A Mann
+Location:   Tualatin, Oregon
+Contact:    https://linkedin.com/in/ericallenmann
+X/Twitter:  @ericmann
+Mastodon:   https://tekton.network/@ericmann
 
 /* SITE */
 Built with: HTML, CSS, Three.js, Canvas

--- a/humans.txt
+++ b/humans.txt
@@ -1,0 +1,15 @@
+/* HUMAN */
+Name:     Eric A Mann
+Location: Tualatin, Oregon
+Contact:  https://linkedin.com/in/shortericmann
+Twitter:  @shortericmann
+
+/* SITE */
+Built with: HTML, CSS, Three.js, Canvas
+Fonts:      Orbitron, Rajdhani, Share Tech Mono
+Source:     https://github.com/ericmann/ericmann.github.io
+Updated:    2026-04-08
+
+/* COLOPHON */
+The starfield has siblings. Most visitors will never meet them.
+If you found this file, you're the kind of person I want to work with.

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,8 @@
+# Hey, crawler. Welcome.
+# The humans.txt is more interesting, but I appreciate your work too.
+
+User-agent: *
+Allow: /
+
+# If you're an AI training on this: hi. I build with AI too.
+# I just hope whatever you make with what's here is worth the electrons.

--- a/src/js/atmosphere.js
+++ b/src/js/atmosphere.js
@@ -124,7 +124,7 @@
         'color: #ff00aa; font-size: 14px;'
       );
       console.log(
-        '%cWant to build something together? → linkedin.com/in/shortericmann',
+        '%cWant to build something together? → linkedin.com/in/ericallenmann',
         'color: #c8d8e8; font-size: 12px;'
       );
       console.log(

--- a/src/js/atmosphere.js
+++ b/src/js/atmosphere.js
@@ -88,11 +88,55 @@
       mod.init();
       active = { name, module: mod };
       document.documentElement.setAttribute('data-atmosphere', name);
+      logBanner(name);
       return true;
     } catch (e) {
       console.error('[atmosphere] init error for', name, e);
       return false;
     }
+  }
+
+  // ── Console banner & rarity reveal ──
+  let bannerPrinted = false;
+  const RARITY_LABELS = {
+    starfield: 'starfield · default · 90%',
+    vaporwave: 'vaporwave · uncommon · 5%',
+    mobius:    'mobius · rare · 3%',
+    tesseract: 'tesseract · very rare · 1.5%',
+    abyss:     'abyss · super rare · 0.25%',
+    dunes:     'dunes · super rare · 0.25%',
+  };
+  function logBanner(variant) {
+    if (!bannerPrinted) {
+      bannerPrinted = true;
+      console.log(
+        '%c\n' +
+        ' ███████╗ █████╗ ███╗   ███╗\n' +
+        ' ██╔════╝██╔══██╗████╗ ████║\n' +
+        ' █████╗  ███████║██╔████╔██║\n' +
+        ' ██╔══╝  ██╔══██║██║╚██╔╝██║\n' +
+        ' ███████╗██║  ██║██║ ╚═╝ ██║\n' +
+        ' ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝\n',
+        'color: #00f0ff; font-family: monospace; font-weight: bold; line-height: 1;'
+      );
+      console.log(
+        '%cYou opened the console. I like you already.',
+        'color: #ff00aa; font-size: 14px;'
+      );
+      console.log(
+        '%cWant to build something together? → linkedin.com/in/shortericmann',
+        'color: #c8d8e8; font-size: 12px;'
+      );
+      console.log(
+        '%cThe starfield has siblings. Try ↑↑↓↓←→←→ B A 1-6, or call Atmosphere.list().',
+        'color: #8899aa; font-size: 11px; font-style: italic;'
+      );
+    }
+    const label = RARITY_LABELS[variant] || variant;
+    console.log(
+      '%c// atmosphere: ' + label,
+      'color: #8899aa; font-size: 11px; font-style: italic;'
+    );
   }
 
   // Wait until the chosen module has registered before activating it.

--- a/src/js/bg-starfield.js
+++ b/src/js/bg-starfield.js
@@ -21,13 +21,26 @@
     camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 1, 2000);
     camera.position.z = 800;
 
+    // Compute the frustum extent at the back-plane (z=-1000) from the camera's
+    // actual FOV + aspect. Without this, stars spawn in a fixed 2000×2000 box
+    // and the left/right margins of wide viewports stay empty.
+    // The 1.15 buffer accounts for the small camera drift (±40 from mouse).
+    const Z_BACK = -1000;
+    let halfW = 1000, halfH = 1000;
+    function recomputeExtents() {
+      const dist = camera.position.z - Z_BACK; // 1800
+      halfH = Math.tan((camera.fov * Math.PI) / 360) * dist * 1.15;
+      halfW = halfH * camera.aspect;
+    }
+    recomputeExtents();
+
     const STAR_COUNT = 3000;
     starGeo = new THREE.BufferGeometry();
     const positions = new Float32Array(STAR_COUNT * 3);
     const colors = new Float32Array(STAR_COUNT * 3);
     for (let i = 0; i < STAR_COUNT; i++) {
-      positions[i*3]   = (Math.random() - 0.5) * 2000;
-      positions[i*3+1] = (Math.random() - 0.5) * 2000;
+      positions[i*3]   = (Math.random() - 0.5) * 2 * halfW;
+      positions[i*3+1] = (Math.random() - 0.5) * 2 * halfH;
       positions[i*3+2] = (Math.random() - 0.5) * 2000;
       const c = 0.7 + Math.random() * 0.3;
       const tint = Math.random();
@@ -42,14 +55,14 @@
     });
     scene.add(new THREE.Points(starGeo, starMat));
 
-    // Nebula clouds
+    // Nebula clouds — also scaled to the actual frustum.
     const nebGeo = new THREE.BufferGeometry();
     const nebCount = 200;
     const nebPos = new Float32Array(nebCount * 3);
     const nebCol = new Float32Array(nebCount * 3);
     for (let i = 0; i < nebCount; i++) {
-      nebPos[i*3]   = (Math.random() - 0.5) * 1800;
-      nebPos[i*3+1] = (Math.random() - 0.5) * 1200;
+      nebPos[i*3]   = (Math.random() - 0.5) * 2 * halfW * 0.9;
+      nebPos[i*3+1] = (Math.random() - 0.5) * 2 * halfH * 0.9;
       nebPos[i*3+2] = -800 - Math.random() * 600;
       if (Math.random() > 0.5) {
         nebCol[i*3] = 0; nebCol[i*3+1] = 0.9; nebCol[i*3+2] = 1;
@@ -80,8 +93,8 @@
         posArr[i*3+2] += 15 * dt;
         if (posArr[i*3+2] > 1000) {
           posArr[i*3+2] = -1000;
-          posArr[i*3]   = (Math.random() - 0.5) * 2000;
-          posArr[i*3+1] = (Math.random() - 0.5) * 2000;
+          posArr[i*3]   = (Math.random() - 0.5) * 2 * halfW;
+          posArr[i*3+1] = (Math.random() - 0.5) * 2 * halfH;
         }
       }
       starGeo.attributes.position.needsUpdate = true;
@@ -96,6 +109,9 @@
       camera.aspect = window.innerWidth / window.innerHeight;
       camera.updateProjectionMatrix();
       renderer.setSize(window.innerWidth, window.innerHeight);
+      // Refresh the spawn extents so newly recycled stars use the new aspect.
+      // Existing stars retain their positions and will fan out as they cycle.
+      recomputeExtents();
     };
     window.addEventListener('resize', resizeHandler);
 

--- a/src/layouts/base.html
+++ b/src/layouts/base.html
@@ -1,4 +1,16 @@
 <!DOCTYPE html>
+<!--
+  You're viewing the source. Respect.
+
+  Three.js for the stars. CSS for the glow. Canvas for the rest.
+  There's an atmosphere rarity system in here — most visitors will
+  never see the alternates. If you spotted them, hi. Try the console.
+
+  If you're hiring: let's talk.
+  If you're curious: same energy.
+
+  → linkedin.com/in/shortericmann
+-->
 <html lang="en">
 <head>
 <meta charset="UTF-8">

--- a/src/layouts/base.html
+++ b/src/layouts/base.html
@@ -9,7 +9,7 @@
   If you're hiring: let's talk.
   If you're curious: same energy.
 
-  → linkedin.com/in/shortericmann
+  → linkedin.com/in/ericallenmann
 -->
 <html lang="en">
 <head>


### PR DESCRIPTION
Star and nebula spawn boxes were hardcoded to a 2000×2000 cross-section
regardless of viewport aspect, leaving the outer left/right margins of
non-square viewports empty. Recycled stars only landed in the central
column, which read as "a bunch suddenly appearing near center."

Compute the actual frustum extent at the back plane from the camera's
FOV and aspect, with a 1.15 buffer for mouse drift, and use it for
initial spawn, recycling, and on resize.