### PR TITLE
Rebalance atmosphere weights, expiry, and accessibility

### DIFF
--- a/src/css/core.css
+++ b/src/css/core.css
@@ -213,11 +213,10 @@ section.auto-height { min-height: auto; }
   margin-bottom: 1rem;
 }
 .about-grid .panel p:last-child { margin-bottom: 0; }
-.stat-row {
-  display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem;
+.stat-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem;
   margin-top: 1.5rem;
 }
-.stat-row + .stat-row { margin-top: 1rem; }
 .stat {
   text-align: center;
   padding: 1rem;
@@ -623,7 +622,7 @@ footer {
   nav ul { gap: 1rem; }
   nav a { font-size: 0.6rem; letter-spacing: 1px; }
   .about-grid { grid-template-columns: 1fr; }
-  .stat-row { grid-template-columns: 1fr 1fr; }
+  .stat-grid { grid-template-columns: 1fr 1fr; }
   section { padding: 5rem 1.25rem; }
   .panel { padding: 1.5rem; }
   .page-content { padding: 6rem 1.25rem 3rem; }

--- a/src/js/atmosphere.js
+++ b/src/js/atmosphere.js
@@ -1,63 +1,121 @@
 // ═══════════════════════════════════════
 // ATMOSPHERE LOADER
-// Picks a background visualization, persists the choice for 24h,
+// Picks a background visualization, persists the choice in a cookie whose
+// expiry is inversely proportional to the rarity of the chosen variant,
 // and listens for the Konami code as a forced override.
 //
-// Each visualization registers itself on window.Atmospheres[name]
-// with { init(), destroy() }. Modules are loaded as separate scripts.
+// Each visualization registers itself on window.Atmospheres[name] with
+// { init(), destroy() }. Modules are loaded as separate scripts.
+//
+// Accessibility: visitors with prefers-reduced-motion always get the
+// starfield (the gentlest variant). The cookie is force-rewritten to match
+// on every load so the preference wins over any prior stored value.
+//
+// Mobile: on touch-primary devices (hover: none and pointer: coarse),
+// non-mobile-friendly variants have their weight divided by 10 for the
+// weighted pick. Their expiry is unchanged — a mobile visitor who DOES
+// land on a heavy variant keeps it as long as anyone else would.
 // ═══════════════════════════════════════
 (function() {
   const COOKIE_NAME = 'eam_atmo';
-  const COOKIE_HOURS = 24;
 
-  // Order matters: index+1 maps to the Konami digit (1..6).
+  // Canonical variant list. Order matters: index+1 is the Konami digit.
+  //   weight          — used for the weighted random pick AND to compute
+  //                     the cookie expiry via expiryHoursFor().
+  //   mobileFriendly  — false means the variant is mouse-dependent or too
+  //                     CPU-heavy for low-power devices, and its weight is
+  //                     divided by 10 on touch-primary devices.
+  //   hidden          — reserved for future secret variants. Hidden ones
+  //                     are excluded from the random pick but still
+  //                     reachable via the Konami Enter cycle and
+  //                     Atmosphere.set(). None currently defined.
   const VARIANTS = [
-    { name: 'starfield',  weight: 90   },
-    { name: 'vaporwave',  weight: 5    },
-    { name: 'mobius',     weight: 3    },
-    { name: 'tesseract',  weight: 1.5  },
-    { name: 'abyss',      weight: 0.25 },
-    { name: 'dunes',      weight: 0.25 },
+    { name: 'starfield', weight: 80, mobileFriendly: true  },
+    { name: 'vaporwave', weight: 4,  mobileFriendly: true  },
+    { name: 'mobius',    weight: 4,  mobileFriendly: true  },
+    { name: 'tesseract', weight: 4,  mobileFriendly: true  },
+    { name: 'abyss',     weight: 4,  mobileFriendly: false },
+    { name: 'dunes',     weight: 4,  mobileFriendly: false },
   ];
 
-  function readCookie(name) {
-    const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
-    return match ? decodeURIComponent(match[1]) : null;
+  // ── Environment checks ──
+  function prefersReducedMotion() {
+    try { return matchMedia('(prefers-reduced-motion: reduce)').matches; }
+    catch (e) { return false; }
+  }
+  function isTouchPrimary() {
+    try { return matchMedia('(hover: none) and (pointer: coarse)').matches; }
+    catch (e) { return false; }
   }
 
-  function writeCookie(name, value, hours) {
+  // Touch devices get the non-mobile-friendly variants at 1/10 weight.
+  function effectiveWeight(v) {
+    if (isTouchPrimary() && !v.mobileFriendly) return v.weight / 10;
+    return v.weight;
+  }
+
+  // Linear interpolation between the two anchor points the user specified:
+  //   weight 80 → 24h  (starfield)
+  //   weight 20 → 168h (7 days)
+  // Extrapolates smoothly for other weights, clamped to [24h, 30d].
+  // Rare variants stick longer so curious visitors can appreciate them.
+  function expiryHoursFor(weight) {
+    const hours = 216 - 2.4 * weight;
+    return Math.max(24, Math.min(720, Math.round(hours)));
+  }
+
+  // ── Cookie helpers ──
+  function readCookie() {
+    const m = document.cookie.match(new RegExp('(?:^|; )' + COOKIE_NAME + '=([^;]*)'));
+    return m ? decodeURIComponent(m[1]) : null;
+  }
+  function writeCookie(variantName) {
+    const v = VARIANTS.find(x => x.name === variantName);
+    // Expiry uses the *canonical* weight; mobile adjustments don't affect it.
+    const hours = v ? expiryHoursFor(v.weight) : 24;
     const exp = new Date(Date.now() + hours * 3600 * 1000).toUTCString();
-    document.cookie = name + '=' + encodeURIComponent(value) + '; expires=' + exp + '; path=/; SameSite=Lax';
+    document.cookie = COOKIE_NAME + '=' + encodeURIComponent(variantName) +
+      '; expires=' + exp + '; path=/; SameSite=Lax';
   }
-
-  function weightedPick() {
-    const total = VARIANTS.reduce((a, v) => a + v.weight, 0);
-    let r = Math.random() * total;
-    for (const v of VARIANTS) {
-      r -= v.weight;
-      if (r <= 0) return v.name;
-    }
-    return VARIANTS[0].name;
+  function clearCookie() {
+    document.cookie = COOKIE_NAME + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
   }
-
   function isValidVariant(name) {
     return VARIANTS.some(v => v.name === name);
   }
 
+  // ── Random pick ──
+  function weightedPick() {
+    const eligible = VARIANTS.filter(v => !v.hidden);
+    const total = eligible.reduce((a, v) => a + effectiveWeight(v), 0);
+    let r = Math.random() * total;
+    for (const v of eligible) {
+      r -= effectiveWeight(v);
+      if (r <= 0) return v.name;
+    }
+    return eligible[0].name;
+  }
+
   function getOrPickVariant() {
-    const stored = readCookie(COOKIE_NAME);
+    // Accessibility: reduced-motion visitors always get the starfield.
+    // We force-rewrite the cookie so a prior stored choice can't bypass it.
+    if (prefersReducedMotion()) {
+      writeCookie('starfield');
+      return 'starfield';
+    }
+    const stored = readCookie();
     if (stored && isValidVariant(stored)) return stored;
     const picked = weightedPick();
-    writeCookie(COOKIE_NAME, picked, COOKIE_HOURS);
+    writeCookie(picked);
     return picked;
   }
 
   // ── Lifecycle ──
   let active = null; // { name, module }
 
-  // Replace a canvas with a clone of itself. A canvas can only ever own one
-  // rendering context (2d OR webgl), and once lost it can't be re-acquired
-  // cleanly — so on swap we simply hand the next module a fresh DOM node.
+  // A canvas can only ever own one rendering context (2d OR webgl), and
+  // once lost it can't be re-acquired cleanly — so on swap we simply hand
+  // the next module a fresh DOM node.
   function freshenCanvas(id) {
     const old = document.getElementById(id);
     if (!old || !old.parentNode) return;
@@ -72,18 +130,13 @@
       console.warn('[atmosphere] module not registered:', name);
       return false;
     }
-
     if (active && active.module) {
       if (typeof active.module.destroy === 'function') {
         try { active.module.destroy(); } catch (e) { console.warn('[atmosphere] destroy error', e); }
       }
-      // Only freshen canvases when swapping — on first activation the
-      // canvases are already pristine and pre-acquiring a context here
-      // would leave Three.js with a half-initialized one.
       freshenCanvas('bg');
       freshenCanvas('fx');
     }
-
     try {
       mod.init();
       active = { name, module: mod };
@@ -96,16 +149,39 @@
     }
   }
 
+  // Advance to the next variant in canonical order. Includes hidden ones
+  // so the Enter-cycle can reach future secret atmospheres.
+  function cycleToNext() {
+    const current = active && active.name;
+    const idx = VARIANTS.findIndex(v => v.name === current);
+    const next = VARIANTS[(idx + 1) % VARIANTS.length];
+    writeCookie(next.name);
+    activateWhenReady(next.name);
+  }
+
+  // Wait until the chosen module has registered before activating it.
+  function activateWhenReady(name, attempt) {
+    attempt = attempt || 0;
+    if (window.Atmospheres && window.Atmospheres[name]) {
+      activate(name);
+      return;
+    }
+    if (attempt > 50) {
+      console.warn('[atmosphere] giving up waiting for', name);
+      const fallback = Object.keys(window.Atmospheres || {})[0];
+      if (fallback) activate(fallback);
+      return;
+    }
+    setTimeout(() => activateWhenReady(name, attempt + 1), 20);
+  }
+
   // ── Console banner & rarity reveal ──
   let bannerPrinted = false;
-  const RARITY_LABELS = {
-    starfield: 'starfield · default · 90%',
-    vaporwave: 'vaporwave · uncommon · 5%',
-    mobius:    'mobius · rare · 3%',
-    tesseract: 'tesseract · very rare · 1.5%',
-    abyss:     'abyss · super rare · 0.25%',
-    dunes:     'dunes · super rare · 0.25%',
-  };
+  function rarityLabel(name) {
+    const v = VARIANTS.find(x => x.name === name);
+    if (!v) return name;
+    return name + ' · ' + v.weight + '%';
+  }
   function logBanner(variant) {
     if (!bannerPrinted) {
       bannerPrinted = true;
@@ -128,35 +204,20 @@
         'color: #c8d8e8; font-size: 12px;'
       );
       console.log(
-        '%cThe starfield has siblings. Try ↑↑↓↓←→←→ B A 1-6, or call Atmosphere.list().',
+        '%cThe starfield has siblings. Try ↑↑↓↓←→←→ B A Enter to cycle, or ↑↑↓↓←→←→ B A 1-' +
+          VARIANTS.length + ' to jump. Atmosphere.list() for names.',
         'color: #8899aa; font-size: 11px; font-style: italic;'
       );
     }
-    const label = RARITY_LABELS[variant] || variant;
     console.log(
-      '%c// atmosphere: ' + label,
+      '%c// atmosphere: ' + rarityLabel(variant),
       'color: #8899aa; font-size: 11px; font-style: italic;'
     );
   }
 
-  // Wait until the chosen module has registered before activating it.
-  function activateWhenReady(name, attempt) {
-    attempt = attempt || 0;
-    if (window.Atmospheres && window.Atmospheres[name]) {
-      activate(name);
-      return;
-    }
-    if (attempt > 50) {
-      console.warn('[atmosphere] giving up waiting for', name);
-      // Fall back to whatever is registered.
-      const fallback = Object.keys(window.Atmospheres || {})[0];
-      if (fallback) activate(fallback);
-      return;
-    }
-    setTimeout(() => activateWhenReady(name, attempt + 1), 20);
-  }
-
-  // ── Konami code: ↑↑↓↓←→←→ B A [1-5] ──
+  // ── Konami code ──
+  //   ↑↑↓↓←→←→ B A [1-9]    → jump directly to variant N
+  //   ↑↑↓↓←→←→ B A Enter    → cycle to the next variant
   const KONAMI_PREFIX = [
     'ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
     'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight',
@@ -173,28 +234,34 @@
     for (let i = 0; i < KONAMI_PREFIX.length; i++) {
       if (buffer[i] !== KONAMI_PREFIX[i]) return;
     }
-    const digit = buffer[KONAMI_PREFIX.length];
-    const idx = parseInt(digit, 10) - 1;
+    const last = buffer[KONAMI_PREFIX.length];
+    buffer = [];
+    if (last === 'Enter') {
+      cycleToNext();
+      return;
+    }
+    const idx = parseInt(last, 10) - 1;
     if (idx >= 0 && idx < VARIANTS.length) {
       const target = VARIANTS[idx].name;
-      writeCookie(COOKIE_NAME, target, COOKIE_HOURS);
+      writeCookie(target);
       activateWhenReady(target);
-      buffer = [];
     }
   }
   document.addEventListener('keydown', onKey);
 
-  // Expose a tiny debug API.
+  // Debug API.
   window.Atmosphere = {
-    list: () => VARIANTS.map(v => v.name),
+    list: () => VARIANTS.filter(v => !v.hidden).map(v => v.name),
+    listAll: () => VARIANTS.map(v => v.name),
     current: () => active && active.name,
     set: (name) => {
       if (!isValidVariant(name)) return false;
-      writeCookie(COOKIE_NAME, name, COOKIE_HOURS);
+      writeCookie(name);
       activateWhenReady(name);
       return true;
     },
-    clear: () => { document.cookie = COOKIE_NAME + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'; },
+    next: () => cycleToNext(),
+    clear: clearCookie,
   };
 
   // Boot.

--- a/src/js/bg-tesseract.js
+++ b/src/js/bg-tesseract.js
@@ -124,9 +124,9 @@
       // through hyperspace. Base rate keeps gentle ambient motion when idle.
       const mouseBoost = 1 + Math.abs(mouseX) * 2 + Math.abs(mouseY) * 2;
       // Outer cube: rotates in xw and yw planes — the signature 4D motion.
-      const a = dt * 0.35 * mouseBoost * (mouseX >= 0 ? 1 : -1);
-      const b = dt * 0.21 * mouseBoost * (mouseY >= 0 ? 1 : -1);
-      const c = dt * 0.08;
+      const a = dt * 0.175 * mouseBoost * (mouseX >= 0 ? 1 : -1);
+      const b = dt * 0.105 * mouseBoost * (mouseY >= 0 ? 1 : -1);
+      const c = dt * 0.04;
       const ca = Math.cos(a), sa = Math.sin(a);
       const cb = Math.cos(b), sb = Math.sin(b);
       const cc = Math.cos(c), sc = Math.sin(c);
@@ -148,11 +148,11 @@
       updateLineGeometry(innerLines.geometry, innerVerts4D, innerEdges, 4);
 
       // Slow ambient drift of the whole scene.
-      const t = now * 0.0003;
+      const t = now * 0.00015;
       outerLines.rotation.z = Math.sin(t) * 0.15;
       innerLines.rotation.z = -Math.sin(t * 1.3) * 0.2;
       // Subtle scale pulse — like the cube is "breathing" through 4D.
-      const pulse = 1 + Math.sin(now * 0.0008) * 0.04;
+      const pulse = 1 + Math.sin(now * 0.0004) * 0.04;
       outerLines.scale.setScalar(pulse);
 
       // Cursor parallax: ease the camera toward the mouse offset.

--- a/src/js/bg-vaporwave.js
+++ b/src/js/bg-vaporwave.js
@@ -165,7 +165,7 @@
     document.addEventListener('mousemove', mouseHandler);
 
     let last = performance.now();
-    const SPEED = 220; // outrun cruising speed
+    const SPEED = 110; // outrun cruising speed
 
     function frame(now) {
       raf = requestAnimationFrame(frame);

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -34,17 +34,13 @@
     <div class="panel reveal">
       <div class="panel-header">// telemetry</div>
       <h2>By the Numbers</h2>
-      <div class="stat-row">
+      <div class="stat-grid">
         <div class="stat"><div class="stat-val">20+</div><div class="stat-label">Years Shipping Software</div></div>
         <div class="stat"><div class="stat-val">PHP</div><div class="stat-label">Release Manager</div></div>
         <div class="stat"><div class="stat-val">77%</div><div class="stat-label">of Web Runs PHP</div></div>
-      </div>
-      <div class="stat-row">
         <div class="stat"><div class="stat-val">$4.4B</div><div class="stat-label">IPO Enabled</div></div>
         <div class="stat"><div class="stat-val">IL5</div><div class="stat-label">DoD Cloud Auth</div></div>
         <a href="https://github.com/ericmann" target="_blank" class="stat"><div class="stat-val">1k+</div><div class="stat-label">GitHub Stars</div></a>
-      </div>
-      <div class="stat-row">
         <div class="stat"><div class="stat-val">100+</div><div class="stat-label">AWS Accounts</div></div>
         <a href="#connect" class="stat"><div class="stat-val">5.4k+</div><div class="stat-label">Social Followers</div></a>
         <div class="stat"><div class="stat-val">3</div><div class="stat-label">Degrees (BS×2, MBA)</div></div>


### PR DESCRIPTION
## Summary

- **Weights**: starfield stays dominant at 80%, but the five alt variants are now equally likely at 4% each (was 5 / 3 / 1.5 / 0.25 / 0.25). One in five visitors should stumble into something new.
- **Cookie expiry** scales inversely with weight via linear interpolation through two anchor points: weight 80 → 24h, weight 20 → 168h (7 days). Current 4% variants stick for ~8.6 days so curious visitors get to appreciate them. Clamped to [24h, 30d].
- **Konami Enter cycle**: `↑↑↓↓←→←→ B A Enter` now advances to the next variant in canonical order (wraps at the end). Digits 1–6 still jump directly. The cycle iterates through all variants including future `hidden: true` ones — schema supports them now, none defined yet.
- **Accessibility**: `prefers-reduced-motion: reduce` visitors are locked to the starfield. The cookie is force-rewritten on each load so the preference wins over any prior stored choice.
- **Mobile**: on `(hover: none) and (pointer: coarse)` devices, non-mobile-friendly variants have their weight divided by 10 for the weighted pick. Their cookie expiry is unchanged. Abyss and dunes are flagged not-mobile-friendly (cursor-dependent interaction + heavier CPU load respectively).
- **Vaporwave** slowed by half: `SPEED 220 → 110` cascades through grid scroll, secondary grid, and chevron drift.
- **Tesseract** slowed by half: primary 4D rotation rates (a, b, c) and slow ambient time factors all halved. Mouse boost multiplier preserved, so cursor motion still accelerates the cube from the new gentler baseline.
- **Debug API** gains `Atmosphere.next()` and `Atmosphere.listAll()`. Console banner updates to mention the Enter-cycle option.

## Test plan

- [ ] Load the site on desktop; confirm starfield renders at 80% rate
- [ ] Clear cookie, reload several times, verify non-starfield picks feel ~4% each
- [ ] `↑↑↓↓←→←→ B A Enter` cycles through variants in order, wraps correctly
- [ ] `↑↑↓↓←→←→ B A 4` jumps directly to tesseract
- [ ] Verify cookie `eam_atmo` expires ~24h after landing on starfield, ~8.6d after landing on a rare variant
- [ ] Toggle OS reduced-motion preference, reload, confirm locked to starfield even if cookie says otherwise
- [ ] Open on a phone; confirm touch-primary detection reduces abyss/dunes frequency
- [ ] Verify vaporwave and tesseract both feel noticeably slower than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)